### PR TITLE
test: switch back to usual test runner

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test-e2e:
     name: Test end-to-end
-    runs-on: ubuntu-e2e
+    runs-on: ubuntu-latest-8-core
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
I set up this other runner while testing things out last week but we don't need it. I'll remove the other runner after this lands.